### PR TITLE
[feat]: 카카오 로그인 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,13 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    implementation 'org.springframework.data:spring-data-envers'
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/com/example/basketballmatching/auth/config/AppConfig.java
+++ b/src/main/java/com/example/basketballmatching/auth/config/AppConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class AppConfig {
@@ -14,4 +15,9 @@ public class AppConfig {
         return new BCryptPasswordEncoder();
     }
 
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 }

--- a/src/main/java/com/example/basketballmatching/auth/config/JwtParserConfig.java
+++ b/src/main/java/com/example/basketballmatching/auth/config/JwtParserConfig.java
@@ -1,0 +1,22 @@
+package com.example.basketballmatching.auth.config;
+
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.nio.charset.StandardCharsets;
+
+@Configuration
+public class JwtParserConfig {
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+    @Bean
+    public JwtParser jwtParser() {
+        return Jwts.parserBuilder().setSigningKey(secretKey.getBytes(
+                StandardCharsets.UTF_8)).build();
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/config/SecurityConfig.java
+++ b/src/main/java/com/example/basketballmatching/auth/config/SecurityConfig.java
@@ -5,19 +5,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+
 
 
 
@@ -34,8 +34,8 @@ public class SecurityConfig {
                         .requestMatchers("/h2-console/**").permitAll() // H2 콘솔에 대한 접근 허용
                         .anyRequest().permitAll())
                 .headers(headers -> headers
-                        .frameOptions(frameOptions -> frameOptions.sameOrigin())); // frameOptions 설정 업데이트
-
+                        .frameOptions(frameOptions -> frameOptions.sameOrigin()));
         return httpSecurity.build();
     }
+
 }

--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -1,11 +1,16 @@
 package com.example.basketballmatching.auth.controller;
 
+import com.example.basketballmatching.auth.dto.SignInDto;
 import com.example.basketballmatching.auth.dto.SignUpDto;
+import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.dto.SendMailRequest;
 import com.example.basketballmatching.global.dto.VerifyMailRequest;
 import com.example.basketballmatching.global.service.MailService;
+import com.example.basketballmatching.user.dto.UserDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -39,6 +44,22 @@ public class AuthController {
     public ResponseEntity<?> sendVerifyMail(@RequestBody VerifyMailRequest request) {
         mailService.verifyEmail(request.getEmail(), request.getCode());
         return ResponseEntity.status(HttpStatus.OK).build();
+    }
+
+    @PostMapping("/signIn")
+    public ResponseEntity<?> signIn(
+            @RequestBody @Valid SignInDto.Request request
+            ) {
+
+        UserDto userDto = authService.signIn(request);
+
+        TokenDto token = authService.getToken(userDto);
+
+
+        return ResponseEntity.ok()
+                .body(SignInDto.Response.fromDto(userDto,
+                        token.getRefreshToken()));
+
     }
 
 }

--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -7,10 +7,10 @@ import com.example.basketballmatching.auth.service.AuthService;
 import com.example.basketballmatching.global.dto.SendMailRequest;
 import com.example.basketballmatching.global.dto.VerifyMailRequest;
 import com.example.basketballmatching.global.service.MailService;
+import com.example.basketballmatching.user.service.UserService;
 import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -31,6 +31,8 @@ public class AuthController {
     private final AuthService authService;
 
     private final MailService mailService;
+
+    private final UserService userService;
 
     @PostMapping
     public ResponseEntity<?> signUpMember(@RequestBody SignUpDto request) {
@@ -76,6 +78,22 @@ public class AuthController {
         authService.logOut(request, userEntity);
 
         return ResponseEntity.ok(HttpStatus.OK);
+    }
+
+    @PostMapping("/refresh-token")
+    public ResponseEntity<?> refreshToken(HttpServletRequest request, @AuthenticationPrincipal UserEntity userEntity) {
+
+        TokenDto tokenDto = authService.refreshToken(request, userEntity);
+
+        UserDto userInfo = userService.getUserInfo(tokenDto.getLoginId());
+
+        HttpHeaders responseHeader = new HttpHeaders();
+
+        responseHeader.set("Authorization", tokenDto.getAccessToken());
+
+        return ResponseEntity.ok()
+                .headers(responseHeader)
+                .body(SignInDto.Response.fromDto(userInfo, tokenDto.getRefreshToken()));
     }
 
 }

--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -8,11 +8,15 @@ import com.example.basketballmatching.global.dto.SendMailRequest;
 import com.example.basketballmatching.global.dto.VerifyMailRequest;
 import com.example.basketballmatching.global.service.MailService;
 import com.example.basketballmatching.user.dto.UserDto;
+import com.example.basketballmatching.user.entity.UserEntity;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,23 +52,30 @@ public class AuthController {
 
     @PostMapping("/signIn")
     public ResponseEntity<?> signIn(
-            @RequestBody @Valid SignInDto.Request request
+            @RequestBody @Validated SignInDto.Request request
             ) {
 
         UserDto userDto = authService.signIn(request);
 
         TokenDto token = authService.getToken(userDto);
 
-        HttpHeaders responseAccessToken = new HttpHeaders();
+        HttpHeaders responseHeader = new HttpHeaders();
 
-        responseAccessToken.set("Authorization", token.getAccessToken());
+        responseHeader.set("Authorization", token.getAccessToken());
 
 
         return ResponseEntity.ok()
-                .header(String.valueOf(responseAccessToken))
+                .headers(responseHeader)
                 .body(SignInDto.Response.fromDto(userDto,
                         token.getRefreshToken()));
 
+    }
+
+    @PostMapping("/logOut")
+    public ResponseEntity<?> logOut(HttpServletRequest request, @AuthenticationPrincipal UserEntity userEntity) {
+        authService.logOut(request, userEntity);
+
+        return ResponseEntity.ok(HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
+++ b/src/main/java/com/example/basketballmatching/auth/controller/AuthController.java
@@ -55,8 +55,13 @@ public class AuthController {
 
         TokenDto token = authService.getToken(userDto);
 
+        HttpHeaders responseAccessToken = new HttpHeaders();
+
+        responseAccessToken.set("Authorization", token.getAccessToken());
+
 
         return ResponseEntity.ok()
+                .header(String.valueOf(responseAccessToken))
                 .body(SignInDto.Response.fromDto(userDto,
                         token.getRefreshToken()));
 

--- a/src/main/java/com/example/basketballmatching/auth/dto/SignInDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/SignInDto.java
@@ -40,7 +40,6 @@ public class SignInDto {
 
         private String name;
 
-        private String phone;
 
         private LocalDate birth;
 
@@ -60,7 +59,6 @@ public class SignInDto {
                     .password(userDto.getPassword())
                     .email(userDto.getEmail())
                     .name(userDto.getName())
-                    .phone(userDto.getPhone())
                     .birth(userDto.getBirth())
                     .genderType(userDto.getGenderType())
                     .userType(userDto.getUserType())

--- a/src/main/java/com/example/basketballmatching/auth/dto/SignInDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/SignInDto.java
@@ -50,6 +50,8 @@ public class SignInDto {
 
         private String position;
 
+        private String refreshToken;
+
         public static Response fromDto(UserDto userDto, String refreshToken) {
 
             return Response.builder()
@@ -63,6 +65,7 @@ public class SignInDto {
                     .genderType(userDto.getGenderType())
                     .userType(userDto.getUserType())
                     .position(userDto.getPosition())
+                    .refreshToken(refreshToken)
                     .build();
 
         }

--- a/src/main/java/com/example/basketballmatching/auth/dto/SignInDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/SignInDto.java
@@ -1,0 +1,78 @@
+package com.example.basketballmatching.auth.dto;
+
+import com.example.basketballmatching.user.dto.UserDto;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+import java.time.LocalDate;
+
+
+public class SignInDto {
+
+
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Request {
+        @NotBlank(message = "아아디를 입력하세요.")
+        private String loginId;
+
+        @NotBlank(message = "비밀번호를 입력하세요.")
+        private String password;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Response {
+
+        private Integer userId;
+
+        private String loginId;
+
+        private String password;
+
+        private String email;
+
+        private String name;
+
+        private String phone;
+
+        private LocalDate birth;
+
+        private String genderType;
+
+        private String userType;
+
+        private String position;
+
+        public static Response fromDto(UserDto userDto, String refreshToken) {
+
+            return Response.builder()
+                    .userId(userDto.getUserId())
+                    .loginId(userDto.getLoginId())
+                    .password(userDto.getPassword())
+                    .email(userDto.getEmail())
+                    .name(userDto.getName())
+                    .phone(userDto.getPhone())
+                    .birth(userDto.getBirth())
+                    .genderType(userDto.getGenderType())
+                    .userType(userDto.getUserType())
+                    .position(userDto.getPosition())
+                    .build();
+
+        }
+
+
+
+    }
+
+
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/dto/SignUpDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/SignUpDto.java
@@ -1,7 +1,7 @@
 package com.example.basketballmatching.auth.dto;
 
 
-import com.example.basketballmatching.user.entity.User;
+import com.example.basketballmatching.user.entity.UserEntity;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
@@ -37,17 +37,17 @@ public class SignUpDto {
 
 
 
-    public static SignUpDto fromEntity(User user) {
+    public static SignUpDto fromEntity(UserEntity userEntity) {
 
         return SignUpDto.builder()
-                .loginId(user.getLoginId())
-                .password(user.getPassword())
-                .email(user.getEmail())
-                .name(user.getName())
-                .phone(user.getPhone())
-                .userType(String.valueOf(user.getUserType()))
-                .genderType(String.valueOf(user.getGenderType()))
-                .position(String.valueOf(user.getPosition()))
+                .loginId(userEntity.getLoginId())
+                .password(userEntity.getPassword())
+                .email(userEntity.getEmail())
+                .name(userEntity.getName())
+                .phone(userEntity.getPhone())
+                .userType(String.valueOf(userEntity.getUserType()))
+                .genderType(String.valueOf(userEntity.getGenderType()))
+                .position(String.valueOf(userEntity.getPosition()))
                 .build();
     }
 

--- a/src/main/java/com/example/basketballmatching/auth/dto/SignUpDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/SignUpDto.java
@@ -6,6 +6,9 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @NoArgsConstructor
@@ -29,11 +32,17 @@ public class SignUpDto {
     @NotBlank(message = "휴대폰번호를 입력해주세요.")
     private String phone;
 
+    private LocalDate birth;
+
     private String userType;
 
     private String genderType;
 
     private String position;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime deletedAt;
 
 
 
@@ -45,9 +54,12 @@ public class SignUpDto {
                 .email(userEntity.getEmail())
                 .name(userEntity.getName())
                 .phone(userEntity.getPhone())
+                .birth(userEntity.getBirth())
                 .userType(String.valueOf(userEntity.getUserType()))
                 .genderType(String.valueOf(userEntity.getGenderType()))
                 .position(String.valueOf(userEntity.getPosition()))
+                .createdAt(userEntity.getCreatedAt())
+                .deletedAt(userEntity.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/com/example/basketballmatching/auth/dto/SignUpDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/SignUpDto.java
@@ -53,7 +53,6 @@ public class SignUpDto {
                 .password(userEntity.getPassword())
                 .email(userEntity.getEmail())
                 .name(userEntity.getName())
-                .phone(userEntity.getPhone())
                 .birth(userEntity.getBirth())
                 .userType(String.valueOf(userEntity.getUserType()))
                 .genderType(String.valueOf(userEntity.getGenderType()))

--- a/src/main/java/com/example/basketballmatching/auth/dto/TokenDto.java
+++ b/src/main/java/com/example/basketballmatching/auth/dto/TokenDto.java
@@ -1,0 +1,22 @@
+package com.example.basketballmatching.auth.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenDto {
+
+    private String loginId;
+
+    private String accessToken;
+
+    private String refreshToken;
+
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/security/AuthenticationFilter.java
+++ b/src/main/java/com/example/basketballmatching/auth/security/AuthenticationFilter.java
@@ -1,0 +1,65 @@
+package com.example.basketballmatching.auth.security;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthenticationFilter extends OncePerRequestFilter {
+
+    @Value("${spring.jwt.header}")
+    private String tokenHeader;
+
+    @Value("${spring.jwt.prefix}")
+    private String tokenPrefix;
+
+
+    private final TokenProvider tokenProvider;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String accessToken = resolvedTokenFromRequest(request);
+
+        if(StringUtils.hasText(accessToken) && tokenProvider.validateToken(accessToken)) {
+
+            Authentication authentication = tokenProvider.getAuthentication(accessToken);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            log.info(String.format("[%s] -> [%s]"), tokenProvider.getUsername(accessToken), request.getRequestURI());
+
+        }
+
+        filterChain.doFilter(request, response);
+
+    }
+
+    private String resolvedTokenFromRequest(HttpServletRequest request) {
+        String token = request.getHeader(tokenHeader);
+
+        if (!ObjectUtils.isEmpty(token) && token.startsWith(tokenPrefix)) {
+            return token.substring(tokenPrefix.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/basketballmatching/auth/security/AuthenticationFilter.java
+++ b/src/main/java/com/example/basketballmatching/auth/security/AuthenticationFilter.java
@@ -1,13 +1,15 @@
 package com.example.basketballmatching.auth.security;
 
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -16,20 +18,19 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Map;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class AuthenticationFilter extends OncePerRequestFilter {
 
-    @Value("${spring.jwt.header}")
-    private String tokenHeader;
-
-    @Value("${spring.jwt.prefix}")
-    private String tokenPrefix;
-
+    public static final String TOKEN_HEADER = "Authorization";
+    public static final String TOKEN_PREFIX = "Bearer ";
 
     private final TokenProvider tokenProvider;
+
+    private final ObjectMapper objectMapper;
 
 
 
@@ -38,14 +39,32 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 
         String accessToken = resolvedTokenFromRequest(request);
 
-        if(StringUtils.hasText(accessToken) && tokenProvider.validateToken(accessToken)) {
+        try {
 
-            Authentication authentication = tokenProvider.getAuthentication(accessToken);
 
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            if (StringUtils.hasText(accessToken) && tokenProvider.isLogout(accessToken)) {
 
-            log.info(String.format("[%s] -> [%s]"), tokenProvider.getUsername(accessToken), request.getRequestURI());
+                response.setStatus(HttpStatus.UNAUTHORIZED.value());
+                response.setContentType("application/json");
 
+                String errorMessage = objectMapper.writeValueAsString(
+                        Map.of("error", "Unauthorized", "message",
+                                "Your token is invalid"));
+
+                response.getWriter().write(errorMessage);
+
+            } else if (!StringUtils.hasText(accessToken)) {
+                log.warn("Not have Access Token.");
+            } else if (tokenProvider.validateToken(accessToken)) {
+                Authentication authentication = tokenProvider.getAuthentication(accessToken);
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                log.info(String.format("[%s] -> %s", tokenProvider.getUsername(accessToken), request.getRequestURI()));
+
+            }
+        } catch (ExpiredJwtException e) {
+            log.warn("에러 메세지 : " + e.getMessage());
         }
 
         filterChain.doFilter(request, response);
@@ -53,11 +72,15 @@ public class AuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String resolvedTokenFromRequest(HttpServletRequest request) {
-        String token = request.getHeader(tokenHeader);
+        String token = request.getHeader(TOKEN_HEADER);
 
-        if (!ObjectUtils.isEmpty(token) && token.startsWith(tokenPrefix)) {
-            return token.substring(tokenPrefix.length());
+        if (!ObjectUtils.isEmpty(token) && token.startsWith(TOKEN_PREFIX)) {
+            return token.substring(TOKEN_PREFIX.length());
         }
         return null;
     }
+
+
+
+
 }

--- a/src/main/java/com/example/basketballmatching/auth/security/AuthenticationFilter.java
+++ b/src/main/java/com/example/basketballmatching/auth/security/AuthenticationFilter.java
@@ -1,7 +1,6 @@
 package com.example.basketballmatching.auth.security;
 
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -9,7 +8,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -33,7 +31,7 @@ public class AuthenticationFilter extends OncePerRequestFilter {
 
     private final TokenProvider tokenProvider;
 
-    private final ObjectMapper objectMapper;
+
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/com/example/basketballmatching/auth/security/TokenProvider.java
+++ b/src/main/java/com/example/basketballmatching/auth/security/TokenProvider.java
@@ -3,7 +3,7 @@ package com.example.basketballmatching.auth.security;
 
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.service.RedisService;
-import com.example.basketballmatching.user.UserService;
+import com.example.basketballmatching.user.service.UserService;
 import com.example.basketballmatching.user.type.UserType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
@@ -171,6 +171,8 @@ public class TokenProvider {
     public void addToLogOutList(String token) {
         this.logOut.add(token);
     }
+
+
 
 
 

--- a/src/main/java/com/example/basketballmatching/auth/security/TokenProvider.java
+++ b/src/main/java/com/example/basketballmatching/auth/security/TokenProvider.java
@@ -1,0 +1,143 @@
+package com.example.basketballmatching.auth.security;
+
+
+import com.example.basketballmatching.global.service.RedisService;
+import com.example.basketballmatching.user.UserService;
+import com.example.basketballmatching.user.type.UserType;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenProvider {
+
+    @Value("${spring.jwt.secret}")
+    private String secretKey;
+
+    @Value("${spring.jwt.token.access-expiration-time}")
+    private long ACCESS_TOKEN_EXPIRE_TIME;
+
+    @Value("${spring.jwt.token.refresh-expiration-time}")
+    private long REFRESH_TOKEN_EXPIRE_TIME;
+
+
+
+    private final RedisService redisService;
+
+    private final UserService userService;
+
+    public String createAccessToken(String loginId, String email, UserType userType) {
+
+        log.info("Access Token 생성 시작");
+
+        return generateAccessToken(loginId, email, userType, ACCESS_TOKEN_EXPIRE_TIME);
+    }
+
+    public String createRefreshToken(String loginId) {
+        log.info("Refresh Token 생성 시작");
+        String refreshToken = generateRefreshToken(loginId, REFRESH_TOKEN_EXPIRE_TIME);
+
+        redisService.setDataExpire(loginId, refreshToken, REFRESH_TOKEN_EXPIRE_TIME);
+
+        log.info("Refresh Token 저장 완료");
+        return refreshToken;
+
+    }
+
+
+    public String generateAccessToken(String loginId, String email, UserType userType, Long expireTime) {
+        Claims claims = Jwts.claims().setSubject(loginId);
+
+        claims.put("email", email);
+        claims.put("userType", userType);
+
+        return returnToken(claims, expireTime);
+    }
+
+    public String generateRefreshToken(String loginId, Long expireTime) {
+        Claims claims = Jwts.claims().setSubject(loginId);
+
+        return returnToken(claims, expireTime);
+    }
+
+    private String returnToken(Claims claims, Long expireTime) {
+
+        var now = new Date();
+        var expireDate = new Date(now.getTime() + expireTime);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expireDate)
+                .signWith(getSigningKey(secretKey.getBytes(StandardCharsets.UTF_8)))
+                .compact();
+    }
+
+    public static Key getSigningKey(byte[] secretKey) {
+        return Keys.hmacShaKeyFor(secretKey);
+    }
+
+    public Claims parseClaims(String token) {
+
+        try {
+
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey.getBytes(StandardCharsets.UTF_8))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            return !claims.getExpiration().before(new Date());
+        } catch (ExpiredJwtException e) {
+            throw new JwtException("토큰 인증 시간이 만료되었습니다.");
+        } catch (UnsupportedJwtException e) {
+            throw new JwtException("지원하지 않는 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            throw new JwtException("잘못된 토큰입니다.");
+        } catch (MalformedJwtException e) {
+            throw new JwtException("토큰 유형이 잘못되었습니다.");
+        } catch (JwtException e) {
+            throw new JwtException(e.getMessage());
+        }
+    }
+    public String getUsername(String token) {
+        return this.parseClaims(token).getSubject();
+    }
+
+    public Authentication getAuthentication(String jwt) {
+        UserDetails userDetails = userService.loadUserByUsername(
+                getUsername(jwt));
+
+        return new UsernamePasswordAuthenticationToken(
+                userDetails,
+                "",
+                userDetails.getAuthorities()
+        );
+    }
+
+
+
+
+
+
+}

--- a/src/main/java/com/example/basketballmatching/auth/security/TokenProvider.java
+++ b/src/main/java/com/example/basketballmatching/auth/security/TokenProvider.java
@@ -7,6 +7,7 @@ import com.example.basketballmatching.user.UserService;
 import com.example.basketballmatching.user.type.UserType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,6 +19,8 @@ import org.springframework.stereotype.Component;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
@@ -29,11 +32,8 @@ public class TokenProvider {
     @Value("${spring.jwt.secret}")
     private String secretKey;
 
-    @Value("${spring.jwt.token.access-expiration-time}")
-    private long ACCESS_TOKEN_EXPIRE_TIME;
-
-    @Value("${spring.jwt.token.refresh-expiration-time}")
-    private long REFRESH_TOKEN_EXPIRE_TIME;
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 30;
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60;
 
 
 
@@ -41,6 +41,12 @@ public class TokenProvider {
 
     private final UserService userService;
 
+    @Getter
+    private final Set<String> logOut =
+            new ConcurrentSkipListSet<>();
+
+
+    // access 토큰 생성
     public String createAccessToken(String loginId, String email, UserType userType) {
 
         log.info("Access Token 생성 시작");
@@ -48,6 +54,7 @@ public class TokenProvider {
         return generateAccessToken(loginId, email, userType, ACCESS_TOKEN_EXPIRE_TIME);
     }
 
+    // Refresh Token 생성
     public String createRefreshToken(String loginId) {
         log.info("Refresh Token 생성 시작");
         String refreshToken = generateRefreshToken(loginId, REFRESH_TOKEN_EXPIRE_TIME);
@@ -59,6 +66,8 @@ public class TokenProvider {
 
     }
 
+
+    // Token 생성 로직
 
     public String generateAccessToken(String loginId, String email, UserType userType, Long expireTime) {
         Claims claims = Jwts.claims().setSubject(loginId);
@@ -107,6 +116,7 @@ public class TokenProvider {
         }
     }
 
+    // 유효성 검사
     public boolean validateToken(String token) {
         try {
             Claims claims = parseClaims(token);
@@ -125,6 +135,8 @@ public class TokenProvider {
             throw new CustomException(WRONG_TYPE_TOKEN);
         }
     }
+
+    // 토큰에서 loginId 추출
     public String getUsername(String token) {
         return this.parseClaims(token).getSubject();
     }
@@ -140,6 +152,25 @@ public class TokenProvider {
         );
     }
 
+    public boolean isLogout(String token) {
+        return this.logOut.contains(token);
+    }
+
+    public void checkLogOut(String token){
+        if (isLogout(token)) {
+            throw new CustomException(ALREADY_LOGOUT);
+        }
+    }
+
+    public void validationRefreshToken(String token) {
+        if (token.length() == 152 && parseClaims(token).getExpiration().before(new Date())) {
+            throw new CustomException(EXPIRED_REFRESH_TOKEN);
+        }
+    }
+
+    public void addToLogOutList(String token) {
+        this.logOut.add(token);
+    }
 
 
 

--- a/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
@@ -49,7 +49,6 @@ public class AuthService {
                         .password(passwordEncoder.encode(request.getPassword()))
                         .email(request.getEmail())
                         .name(request.getName())
-                        .phone(request.getPhone())
                         .birth(LocalDate.now())
                         .userType(UserType.USER)
                         .genderType(GenderType.valueOf(request.getGenderType()))

--- a/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
+++ b/src/main/java/com/example/basketballmatching/auth/service/AuthService.java
@@ -6,25 +6,36 @@ import com.example.basketballmatching.auth.dto.SignUpDto;
 import com.example.basketballmatching.auth.dto.TokenDto;
 import com.example.basketballmatching.auth.security.TokenProvider;
 import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.service.RedisService;
 import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import com.example.basketballmatching.user.type.GenderType;
 import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static com.example.basketballmatching.global.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthService {
 
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
+    private final RedisService redisService;
 
     public SignUpDto signUp(SignUpDto request) {
         if (userRepository.existsByEmail(request.getEmail())) {
@@ -39,9 +50,11 @@ public class AuthService {
                         .email(request.getEmail())
                         .name(request.getName())
                         .phone(request.getPhone())
+                        .birth(LocalDate.now())
                         .userType(UserType.USER)
                         .genderType(GenderType.valueOf(request.getGenderType()))
                         .position(Position.valueOf(request.getPosition()))
+                        .createdAt(LocalDateTime.now())
                         .build()
         );
 
@@ -71,6 +84,106 @@ public class AuthService {
 
         return new TokenDto(userDto.getLoginId(), accessToken, refreshToken);
 
+    }
+
+    public TokenDto refreshToken(HttpServletRequest request, UserEntity userEntity) {
+
+        String expiredAccessToken = validateAccessToken(request);
+
+        String refreshToken = validateRefreshToken(request);
+
+        Claims claims = tokenProvider.parseClaims(refreshToken);
+
+        String loginId = claims.get("loginId", String.class);
+
+        String email = claims.get("email", String.class);
+
+        UserType userType = (UserType) claims.get("userType");
+
+        if (!tokenMatch(expiredAccessToken, refreshToken)) {
+            throw new CustomException(TOKEN_NOT_MATCH);
+        }
+
+        if (!userEntity.getLoginId().equals(loginId)) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+
+        try {
+            redisService.findByLoginId(loginId);
+        } catch (Exception e) {
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+
+        userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        String accessToken = tokenProvider.createAccessToken(loginId, email, userType);
+
+        return new TokenDto(loginId, accessToken, refreshToken);
+    }
+
+    public void logOut(HttpServletRequest request, UserEntity userEntity) {
+
+        String accessToken = validateAccessToken(request);
+        String refreshToken = validateRefreshToken(request);
+
+        if(accessToken.isEmpty()) {
+            throw new CustomException(INVALID_TOKEN);
+        }
+
+        Claims claims = tokenProvider.parseClaims(accessToken);
+        String loginId = claims.getSubject();
+
+        if (tokenMatch(accessToken, refreshToken) && loginId.equals(userEntity.getLoginId())) {
+            redisService.deleteData(loginId);
+        } else {
+            throw new CustomException(INVALID_TOKEN);
+        }
+
+        tokenProvider.addToLogOutList(accessToken);
+
+    }
+
+    private String validateAccessToken(HttpServletRequest request) {
+        log.info("AccessToken 검증 시작");
+
+        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+        log.info("Authorization Header: {}", token); // 헤더 로그 출력
+
+        if (!ObjectUtils.isEmpty(token) && token.startsWith("Bearer ")) {
+            log.info("검증 완료");
+            return token.substring("Bearer ".length());
+        } else {
+            log.error("AccessToken이 없거나 형식이 잘못되었습니다."); // 에러 로그 출력
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+    }
+
+    private String validateRefreshToken(HttpServletRequest request) {
+        log.info("RefreshToken 검증 시작");
+
+        String token = request.getHeader("refreshToken");
+        log.info("RefreshToken Header: {}", token); // 헤더 로그 출력
+
+        if (!ObjectUtils.isEmpty(token) && token.startsWith("Bearer ")) {
+            return token.substring("Bearer ".length());
+        } else {
+            log.error("RefreshToken이 없거나 형식이 잘못되었습니다."); // 에러 로그 출력
+            throw new CustomException(NOT_FOUND_TOKEN);
+        }
+    }
+
+
+    private boolean tokenMatch(String accessToken, String refreshToken) {
+
+        Claims accessClaims = tokenProvider.parseClaims(accessToken);
+
+        Claims refreshClaims = tokenProvider.parseClaims(refreshToken);
+
+        String accessId = accessClaims.getSubject();
+        String refreshId = refreshClaims.getSubject();
+
+        return accessId.equals(refreshId);
     }
 
 }

--- a/src/main/java/com/example/basketballmatching/global/config/RedisConfig.java
+++ b/src/main/java/com/example/basketballmatching/global/config/RedisConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -41,6 +42,11 @@ public class RedisConfig {
 
         return redisTemplate;
     }
+
+
+
+
+
 
 
 }

--- a/src/main/java/com/example/basketballmatching/global/exception/CustomException.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/CustomException.java
@@ -1,16 +1,25 @@
 package com.example.basketballmatching.global.exception;
 
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class CustomException extends RuntimeException{
 
-    private final ErrorCode errorCode;
+    private ErrorCode errorCode;
+    private String errorMessage;
 
     public CustomException(ErrorCode errorCode) {
         super(errorCode.getDescription());
         this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+
     }
 
 }

--- a/src/main/java/com/example/basketballmatching/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/CustomExceptionHandler.java
@@ -3,30 +3,60 @@ package com.example.basketballmatching.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import static com.example.basketballmatching.global.exception.ErrorCode.INTERNAL_SERVER_ERROR;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @RestControllerAdvice
 public class CustomExceptionHandler {
 
-
     @ExceptionHandler(CustomException.class)
-    public ErrorResponse handleCustomException(CustomException e) {
-        log.error("CustomException is occurred." + e);
-
-        return new ErrorResponse(e.getErrorCode(),
-                e.getErrorCode().getHttpStatus(), e.getErrorCode().getDescription());
+    protected ResponseEntity<ErrorResponse> handleMyException(CustomException e) {
+        ErrorResponse errorResponse = new ErrorResponse(e.getErrorCode());
+        HttpStatus httpStatus = HttpStatus.valueOf(e.getErrorCode().getHttpStatus());
+        return new ResponseEntity<>(errorResponse, httpStatus);
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> methodValidException(
+            MethodArgumentNotValidException exception) {
 
-    @ExceptionHandler(Exception.class)
-    public ErrorResponse handleException(Exception e) {
-        log.error("Exception is occurred." + e);
-        return new ErrorResponse(INTERNAL_SERVER_ERROR,
-                HttpStatus.INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR.getDescription());
+        ErrorResponse errorResponse =
+                makeErrorResponse(exception.getBindingResult());
+
+        return new ResponseEntity<>(errorResponse,
+                HttpStatus.BAD_REQUEST);
     }
 
+    private ErrorResponse makeErrorResponse(BindingResult bindingResult) {
+
+        ErrorCode errorCode = null;
+        List<String> details = new ArrayList<>();
+
+        if (bindingResult.hasErrors()) {
+            for (FieldError error : bindingResult.getFieldErrors()) {
+                String field = error.getField();
+                String defaultMessage = error.getDefaultMessage();
+                String bindResultCode = error.getCode();
+
+                errorCode = switch (Objects.requireNonNull(bindResultCode)) {
+                    case "NotBlank" -> ErrorCode.INVALID_INPUT;
+                    case "Email" -> ErrorCode.INVALID_PATTERN;
+                    default -> ErrorCode.INTERNAL_SERVER_ERROR;
+                };
+
+                details.add(field + " : " + defaultMessage);
+            }
+        }
+
+        return new ErrorResponse(errorCode, details);
+    }
 }

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -9,17 +9,28 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),
-    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다"),
+    //user
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 코드입니다."),
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다"),
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-
     ALREADY_EXIST_USER(HttpStatus.CONFLICT, "이미 존재하는 회원입니다."),
-
     CONFIRM_EMAIL_AUTH(HttpStatus.BAD_REQUEST, "이메일 인증을 확인해주세요."),
+    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 인증 코드입니다."),
+
+
+
+    // server
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),
+
+
     // token
-    EXPIRED_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "리프레시 토큰의 기간이 만료되었습니다.");
+    EXPIRED_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "리프레시 토큰의 기간이 만료되었습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "리소스 접근 권한이 없습니다."),
+    UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않는 토큰입니다."),
+    WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 형식의 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다. 재발급 받아주세요."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원되지 않는 토큰입니다."),;
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -11,10 +11,15 @@ public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),
     EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 코드입니다."),
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 
-    ALREADY_EXIST_USER(HttpStatus.CONFLICT, "이미 존재하는 회원입니다.");
+    ALREADY_EXIST_USER(HttpStatus.CONFLICT, "이미 존재하는 회원입니다."),
+
+    CONFIRM_EMAIL_AUTH(HttpStatus.BAD_REQUEST, "이메일 인증을 확인해주세요."),
+    // token
+    EXPIRED_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "리프레시 토큰의 기간이 만료되었습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -10,30 +10,32 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     //user
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 이메일입니다"),
-    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
-    ALREADY_EXIST_USER(HttpStatus.CONFLICT, "이미 존재하는 회원입니다."),
-    CONFIRM_EMAIL_AUTH(HttpStatus.BAD_REQUEST, "이메일 인증을 확인해주세요."),
-    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 인증 코드입니다."),
-
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "사용자를 찾을 수 없습니다."),
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "존재하지 않는 이메일입니다"),
+    PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST.value(), "비밀번호가 일치하지 않습니다."),
+    ALREADY_EXIST_USER(HttpStatus.CONFLICT.value(), "이미 존재하는 회원입니다."),
+    CONFIRM_EMAIL_AUTH(HttpStatus.BAD_REQUEST.value(), "이메일 인증을 확인해주세요."),
+    INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST.value(), "유효하지 않은 이메일 인증 코드입니다."),
+    ALREADY_LOGOUT(HttpStatus.BAD_REQUEST.value(), "이미 로그아웃 하였습니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST.value(), "필수 입력 값이 누락되었습니다."),
+    INVALID_PATTERN(HttpStatus.BAD_REQUEST.value(), "형식에 맞게 입력 해야합니다."),
 
 
     // server
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "내부 서버 오류가 발생했습니다."),
 
 
     // token
-    EXPIRED_REFRESH_TOKEN(HttpStatus.FORBIDDEN, "리프레시 토큰의 기간이 만료되었습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "리소스 접근 권한이 없습니다."),
-    UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않는 토큰입니다."),
-    WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "잘못된 형식의 토큰입니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰이 만료되었습니다. 재발급 받아주세요."),
-    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "지원되지 않는 토큰입니다."),;
+    EXPIRED_REFRESH_TOKEN(HttpStatus.FORBIDDEN.value(), "리프레시 토큰의 기간이 만료되었습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED.value(), "리소스 접근 권한이 없습니다."),
+    UNKNOWN_ERROR(HttpStatus.UNAUTHORIZED.value(), "토큰이 존재하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "유효하지 않는 토큰입니다."),
+    WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED.value(), "잘못된 형식의 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "액세스 토큰이 만료되었습니다. 재발급 받아주세요."),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "지원되지 않는 토큰입니다."),;
 
 
-    private final HttpStatus httpStatus;
+    private final int httpStatus;
     private final String description;
 
 }

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorCode.java
@@ -32,7 +32,9 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "유효하지 않는 토큰입니다."),
     WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED.value(), "잘못된 형식의 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "액세스 토큰이 만료되었습니다. 재발급 받아주세요."),
-    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "지원되지 않는 토큰입니다."),;
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "지원되지 않는 토큰입니다."),
+    NOT_FOUND_TOKEN(HttpStatus.NOT_FOUND.value(), "토큰을 찾을 수 없습니다.")
+    ,TOKEN_NOT_MATCH(HttpStatus.BAD_REQUEST.value(), "토큰이 일치하지 않습니다.");
 
 
     private final int httpStatus;

--- a/src/main/java/com/example/basketballmatching/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/basketballmatching/global/exception/ErrorResponse.java
@@ -5,13 +5,28 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.springframework.http.HttpStatus;
 
+import java.util.List;
+
 @Data
 @AllArgsConstructor
 public class ErrorResponse {
 
-
+    private int statusCode;
     private ErrorCode errorCode;
-    private HttpStatus httpStatus;
-    private String description;
+    private String errorMessage;
+    private List<String> details;
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this.statusCode = errorCode.getHttpStatus();
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+
+    public ErrorResponse(ErrorCode errorCode, List<String> details) {
+        this.statusCode = errorCode.getHttpStatus();
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+        this.details = details;
+    }
 
 }

--- a/src/main/java/com/example/basketballmatching/global/service/MailService.java
+++ b/src/main/java/com/example/basketballmatching/global/service/MailService.java
@@ -3,7 +3,7 @@ package com.example.basketballmatching.global.service;
 
 import com.example.basketballmatching.global.dto.SendMailResponse;
 import com.example.basketballmatching.global.exception.CustomException;
-import com.example.basketballmatching.user.entity.User;
+import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
@@ -85,11 +85,11 @@ public class MailService {
             throw new CustomException(INVALID_AUTH_CODE);
         }
 
-        User user = userRepository.findByEmail(email)
+        UserEntity userEntity = userRepository.findByEmail(email)
                 .orElseThrow(() -> new CustomException(EMAIL_NOT_FOUND));
 
-        user.changeEmailAuth();
-        userRepository.save(user);
+        userEntity.changeEmailAuth();
+        userRepository.save(userEntity);
 
         redisService.deleteData(EMAIL_PREFIX + email);
 

--- a/src/main/java/com/example/basketballmatching/global/service/RedisService.java
+++ b/src/main/java/com/example/basketballmatching/global/service/RedisService.java
@@ -25,6 +25,10 @@ public class RedisService {
         valueOperations.set(key, value, Duration.ofMillis(expiredTime));
     }
 
+    public void findByLoginId(String id) {
+        redisTemplate.opsForValue().get(id);
+    }
+
     public boolean existData(String key) {
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }

--- a/src/main/java/com/example/basketballmatching/user/UserService.java
+++ b/src/main/java/com/example/basketballmatching/user/UserService.java
@@ -2,6 +2,8 @@ package com.example.basketballmatching.user;
 
 import com.example.basketballmatching.global.exception.CustomException;
 import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.dto.UserDto;
+import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -9,6 +11,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.example.basketballmatching.global.exception.ErrorCode.USER_NOT_FOUND;
 
 
 @Service
@@ -22,6 +26,13 @@ public class UserService implements UserDetailsService {
     @Transactional
     public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
         return userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+    }
+
+    public UserDto getUserInfo(String loginId) {
+        UserEntity user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        return UserDto.fromEntity(user);
     }
 }

--- a/src/main/java/com/example/basketballmatching/user/UserService.java
+++ b/src/main/java/com/example/basketballmatching/user/UserService.java
@@ -1,0 +1,27 @@
+package com.example.basketballmatching.user;
+
+import com.example.basketballmatching.global.exception.CustomException;
+import com.example.basketballmatching.global.exception.ErrorCode;
+import com.example.basketballmatching.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+public class UserService implements UserDetailsService {
+
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+        return userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/basketballmatching/user/dto/KakaoDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/KakaoDto.java
@@ -1,0 +1,104 @@
+package com.example.basketballmatching.user.dto;
+
+import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.type.GenderType;
+import com.example.basketballmatching.user.type.UserType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class KakaoDto {
+
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Request {
+
+        private String loginId;
+
+        private String email;
+
+        private String name;
+
+        private String nickname;
+
+        private String gender;
+
+        public static UserEntity toEntity(Request request) {
+
+            BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+            return UserEntity.builder()
+                    .loginId(request.loginId)
+                    .password(encoder.encode("kakao"))
+                    .email(request.email)
+                    .name(request.name)
+                    .birth(LocalDate.now())
+                    .genderType(GenderType.valueOf(request.gender))
+                    .nickname(request.nickname)
+                    .userType(UserType.USER)
+                    .emailAuth(true)
+                    .build();
+        }
+
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Response {
+
+        private Integer id;
+
+        private String loginId;
+
+        private String email;
+
+        @Schema(defaultValue = "방문자")
+        private String name;
+
+        @Schema(defaultValue = "19970724")
+        private LocalDate birth;
+
+        @Schema(defaultValue = "MALE")
+        private String gender;
+
+        private String nickname;
+
+        private LocalDateTime createdAt;
+
+        @Schema(defaultValue = "GUARD")
+        private String position;
+
+        private String userType;
+
+        private String refreshToken;
+
+        public static Response fromDto(UserDto userDto, String refreshToken) {
+
+            return Response.builder()
+                    .id(userDto.getUserId())
+                    .loginId(userDto.getLoginId())
+                    .email(userDto.getEmail())
+                    .name(userDto.getName())
+                    .birth(userDto.getBirth())
+                    .gender(userDto.getGenderType())
+                    .nickname(userDto.getNickname())
+                    .createdAt(userDto.getCreatedAt())
+                    .position(userDto.getPosition())
+                    .userType(userDto.getUserType())
+                    .refreshToken(refreshToken)
+                    .build();
+
+        }
+
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/user/dto/UserDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/UserDto.java
@@ -1,6 +1,6 @@
 package com.example.basketballmatching.user.dto;
 
-import com.example.basketballmatching.user.entity.User;
+import com.example.basketballmatching.user.entity.UserEntity;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -35,20 +35,20 @@ public class UserDto {
 
     private boolean emailAuth;
 
-    public static UserDto fromEntity(User user) {
+    public static UserDto fromEntity(UserEntity userEntity) {
 
         return UserDto.builder()
-                .userId(user.getUserId())
-                .loginId(user.getLoginId())
-                .password(user.getPassword())
-                .email(user.getEmail())
-                .name(user.getName())
-                .phone(user.getPhone())
-                .birth(user.getBirth())
-                .genderType(String.valueOf(user.getGenderType()))
-                .userType(String.valueOf(user.getUserType()))
-                .position(String.valueOf(user.getPosition()))
-                .emailAuth(user.isEmailAuth())
+                .userId(userEntity.getUserId())
+                .loginId(userEntity.getLoginId())
+                .password(userEntity.getPassword())
+                .email(userEntity.getEmail())
+                .name(userEntity.getName())
+                .phone(userEntity.getPhone())
+                .birth(userEntity.getBirth())
+                .genderType(String.valueOf(userEntity.getGenderType()))
+                .userType(String.valueOf(userEntity.getUserType()))
+                .position(String.valueOf(userEntity.getPosition()))
+                .emailAuth(userEntity.isEmailAuth())
                 .build();
     }
 

--- a/src/main/java/com/example/basketballmatching/user/dto/UserDto.java
+++ b/src/main/java/com/example/basketballmatching/user/dto/UserDto.java
@@ -4,6 +4,7 @@ import com.example.basketballmatching.user.entity.UserEntity;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 
 @Getter
@@ -23,7 +24,7 @@ public class UserDto {
 
     private String name;
 
-    private String phone;
+    private String nickname;
 
     private LocalDate birth;
 
@@ -35,6 +36,9 @@ public class UserDto {
 
     private boolean emailAuth;
 
+    private LocalDateTime createdAt;
+
+
     public static UserDto fromEntity(UserEntity userEntity) {
 
         return UserDto.builder()
@@ -43,12 +47,13 @@ public class UserDto {
                 .password(userEntity.getPassword())
                 .email(userEntity.getEmail())
                 .name(userEntity.getName())
-                .phone(userEntity.getPhone())
+                .nickname(userEntity.getNickname())
                 .birth(userEntity.getBirth())
                 .genderType(String.valueOf(userEntity.getGenderType()))
                 .userType(String.valueOf(userEntity.getUserType()))
                 .position(String.valueOf(userEntity.getPosition()))
                 .emailAuth(userEntity.isEmailAuth())
+                .createdAt(userEntity.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/com/example/basketballmatching/user/entity/UserEntity.java
+++ b/src/main/java/com/example/basketballmatching/user/entity/UserEntity.java
@@ -6,9 +6,14 @@ import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 
 @Entity(name = "users")
 @Getter
@@ -16,7 +21,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class User {
+public class UserEntity implements UserDetails {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -62,5 +67,33 @@ public class User {
     }
 
 
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
 
+    @Override
+    public String getUsername() {
+        return loginId;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
 }

--- a/src/main/java/com/example/basketballmatching/user/entity/UserEntity.java
+++ b/src/main/java/com/example/basketballmatching/user/entity/UserEntity.java
@@ -6,9 +6,12 @@ import com.example.basketballmatching.user.type.Position;
 import com.example.basketballmatching.user.type.UserType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -37,13 +40,15 @@ public class UserEntity implements UserDetails {
     @Column(nullable = false)
     private String email;
 
-    private String name;
 
     private String phone;
 
+    private String name;
+
+    private String nickname;
+
     private LocalDate birth;
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private GenderType genderType;
 
@@ -51,16 +56,19 @@ public class UserEntity implements UserDetails {
     @Enumerated(EnumType.STRING)
     private UserType userType;
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Position position;
 
     @Builder.Default
     private boolean emailAuth = false;
 
+    @CreatedDate
     private LocalDateTime createdAt;
 
+    @LastModifiedDate
     private LocalDateTime updatedAt;
+
+    private String refreshToken;
 
     public void changeEmailAuth() {
         this.emailAuth = true;
@@ -96,4 +104,5 @@ public class UserEntity implements UserDetails {
     public boolean isEnabled() {
         return false;
     }
+
 }

--- a/src/main/java/com/example/basketballmatching/user/oauth2/cotroller/OAuth2Controller.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/cotroller/OAuth2Controller.java
@@ -1,0 +1,58 @@
+package com.example.basketballmatching.user.oauth2.cotroller;
+
+
+import com.example.basketballmatching.auth.dto.TokenDto;
+import com.example.basketballmatching.auth.service.AuthService;
+import com.example.basketballmatching.user.dto.KakaoDto;
+import com.example.basketballmatching.user.dto.UserDto;
+import com.example.basketballmatching.user.oauth2.service.OAuth2Service;
+import com.nimbusds.oauth2.sdk.Response;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/oauth2")
+public class OAuth2Controller {
+
+    private final OAuth2Service oAuth2Service;
+    private final AuthService authService;
+
+
+    /**
+     * 카카오 로그인
+     */
+
+    @GetMapping("/login/kakao")
+    public void getKakaoAuthUrl(HttpServletResponse response) throws IOException {
+        response.sendRedirect(oAuth2Service.responseUrl());
+    }
+
+    @GetMapping("/kakao")
+    public ResponseEntity<?> kakaoLogin(
+            @RequestParam(name = "code") String code)
+            throws IOException {
+        log.info("카카오 로그인 시작");
+        UserDto userDto = oAuth2Service.kakaoLogin(code);
+        log.info("토큰 요청");
+        TokenDto tokenDto = authService.getToken(userDto);
+
+        HttpHeaders responseHeaders = new HttpHeaders();
+        responseHeaders.set("Authorization", tokenDto.getAccessToken());
+
+        log.info("카카오 로그인 완료");
+        return ResponseEntity.ok()
+                .headers(responseHeaders)
+                .body(KakaoDto.Response.fromDto(userDto, tokenDto.getRefreshToken()));
+    }
+}

--- a/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoOAuthTokenDto.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoOAuthTokenDto.java
@@ -1,0 +1,27 @@
+package com.example.basketballmatching.user.oauth2.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KakaoOAuthTokenDto {
+
+    private String access_token;
+
+    private String token_type;
+
+    private String refresh_token;
+
+    private String id_token;
+
+    private Integer expires_in;
+
+    private String scope;
+
+    private Integer refresh_token_expires_in;
+}

--- a/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoUserInfoDto.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/dto/KakaoUserInfoDto.java
@@ -1,0 +1,50 @@
+package com.example.basketballmatching.user.oauth2.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class KakaoUserInfoDto {
+
+
+    private Long id;
+
+    private String connected_at;
+
+    private Properties properties;
+
+    private KakaoAccount kakao_account;
+
+
+    @Data
+    public static class Properties {
+        private String nickname;
+    }
+
+    @Data
+    public static class KakaoAccount {
+
+        private boolean profile_nickname_needs_agreement;
+        private Profile profile;
+        private boolean has_email;
+        private boolean email_needs_agreement;
+        @JsonProperty("is_email_valid")
+        private boolean is_email_valid;
+        @JsonProperty("is_email_verified")
+        private boolean is_email_verified;
+        private String email;
+        private boolean has_gender;
+        private boolean gender_needs_agreement;
+        private String gender;
+
+        @Data
+        public static class Profile {
+
+            @JsonProperty("is_default_nickname")
+            private boolean is_default_nickname;
+            private String nickname;
+
+        }
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/user/oauth2/service/OAuth2Service.java
+++ b/src/main/java/com/example/basketballmatching/user/oauth2/service/OAuth2Service.java
@@ -1,0 +1,190 @@
+package com.example.basketballmatching.user.oauth2.service;
+
+import com.example.basketballmatching.auth.dto.SignInDto;
+import com.example.basketballmatching.auth.service.AuthService;
+import com.example.basketballmatching.user.dto.KakaoDto;
+import com.example.basketballmatching.user.dto.UserDto;
+import com.example.basketballmatching.user.oauth2.dto.KakaoOAuthTokenDto;
+import com.example.basketballmatching.user.oauth2.dto.KakaoUserInfoDto;
+import com.example.basketballmatching.user.oauth2.dto.KakaoUserInfoDto.KakaoAccount;
+import com.example.basketballmatching.user.oauth2.dto.KakaoUserInfoDto.Properties;
+import com.example.basketballmatching.user.repository.UserRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class OAuth2Service {
+
+    private final UserRepository userRepository;
+    private final AuthService authService;
+
+    @Value("${spring.security.oauth2.client.registration.kakao.client-id}")
+    String clientId;
+    @Value("${spring.security.oauth2.client.registration.kakao.client-secret}")
+    String clientSecret;
+    @Value("${spring.security.oauth2.client.provider.kakao.authorization-uri}")
+    String authorizationUri;
+    @Value("${spring.security.oauth2.client.provider.kakao.token-uri}")
+    String tokenRequestUri;
+
+
+    public String responseUrl() {
+        log.info("카카오 로그인 요청");
+        return authorizationUri + "?client_id=" + clientId + "&redirect_uri=http://localhost:8080/api/oauth2/kakao"
+                + "&response_type=code";
+    }
+
+    public UserDto kakaoLogin(String code) throws JsonProcessingException {
+
+        log.info("카카오 유저 정보 가져오기");
+        KakaoUserInfoDto kakaoUser = getKakaoUserInfoDto(code);
+        Properties properties = kakaoUser.getProperties();
+        KakaoAccount kakaoAccount = kakaoUser.getKakao_account();
+        String loginId = "kakao_" + kakaoUser.getId().toString();
+
+        log.info("카카오 유저 정보 등록");
+
+        if (kakaoAccount.getEmail() == null && kakaoAccount.getGender() == null
+                && !userRepository.existsByLoginId(loginId)) {
+            KakaoDto.Request user = kakaoUserDto(
+                    loginId,
+                    loginId + "@kakao.com",
+                    properties.getNickname()
+                    , "MALE");
+
+            userRepository.save(KakaoDto.Request.toEntity(user));
+        } else if (kakaoAccount.getEmail() == null && kakaoAccount.getGender() != null
+                && !userRepository.existsByLoginId(loginId)) {
+            KakaoDto.Request user = kakaoUserDto(
+                    loginId,
+                    loginId + "@kakao.com",
+                    properties.getNickname()
+                    , kakaoAccount.getGender());
+
+            userRepository.save(KakaoDto.Request.toEntity(user));
+        } else if (kakaoAccount.getEmail() != null && kakaoAccount.getGender() == null
+                && !userRepository.existsByLoginId(loginId)) {
+            KakaoDto.Request user = kakaoUserDto(
+                    loginId,
+                    "kakao_" + kakaoAccount.getEmail(),
+                    properties.getNickname()
+                    , "MALE");
+
+            userRepository.save(KakaoDto.Request.toEntity(user));
+        } else if (!userRepository.existsByLoginId(loginId)) {
+            KakaoDto.Request user = kakaoUserDto(
+                    loginId,
+                    "kakao_" + kakaoAccount.getEmail(),
+                    properties.getNickname()
+                    , kakaoAccount.getGender());
+
+            userRepository.save(KakaoDto.Request.toEntity(user));
+        }
+        log.info("카카오 유저 정보 등록 성공");
+        SignInDto.Request logInDto = kakaoUserLogin(loginId);
+        log.info("카카오 로그인 성공");
+        return authService.signIn(logInDto);
+
+
+    }
+
+    private KakaoUserInfoDto getKakaoUserInfoDto(String code) throws JsonProcessingException {
+
+        log.info("카카오 토큰 요청");
+        ResponseEntity<String> accessTokenResponse = requestAccessToken(code);
+
+        log.info("카카오 토큰 요청 성공");
+        KakaoOAuthTokenDto kakaoOAuthTokenDto = getAccessToken(accessTokenResponse);
+
+        log.info("카카오 유저 정보 요청");
+        ResponseEntity<String> userInfoResponse = requestUserInfo(kakaoOAuthTokenDto);
+
+        log.info("카카오 유저 정보 요청 성공");
+
+        return getUserInfo(userInfoResponse);
+    }
+
+
+    private KakaoDto.Request kakaoUserDto(String loginId, String email, String nickname, String gender) {
+
+        return KakaoDto.Request.builder()
+                .loginId(loginId)
+                .name(nickname)
+                .nickname(nickname)
+                .email(email)
+                .gender(gender.toUpperCase())
+                .build();
+
+    }
+
+    public ResponseEntity<String> requestAccessToken(String code) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+
+        headers.add("Content-type",
+                "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", "http://localhost:8080/api/oauth2/kakao");
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> kakaoRequest = new HttpEntity<>(params, headers);
+
+        return restTemplate.postForEntity(tokenRequestUri, kakaoRequest, String.class);
+
+    }
+
+    public KakaoOAuthTokenDto getAccessToken(ResponseEntity<String> response) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        return objectMapper.readValue(response.getBody(), KakaoOAuthTokenDto.class);
+
+    }
+
+    public ResponseEntity<String> requestUserInfo(
+            KakaoOAuthTokenDto oAuthTokenDto
+    ) {
+
+        HttpHeaders headers = new HttpHeaders();
+        RestTemplate restTemplate = new RestTemplate();
+
+        headers.add("Authorization", "Bearer " + oAuthTokenDto.getAccess_token());
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+
+        return restTemplate.exchange("https://kapi.kakao.com/v2/user/me",
+                HttpMethod.GET, request, String.class);
+    }
+
+    public KakaoUserInfoDto getUserInfo(ResponseEntity<String> response) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        return objectMapper.readValue(response.getBody(), KakaoUserInfoDto.class);
+    }
+
+    public SignInDto.Request kakaoUserLogin(String id) {
+
+        return SignInDto.Request.builder()
+                .loginId(id)
+                .password("kakao")
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
+++ b/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.example.basketballmatching.user.repository;
 
 
 import com.example.basketballmatching.user.entity.UserEntity;
+import com.example.basketballmatching.user.type.SocialType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -10,9 +11,13 @@ public interface UserRepository extends JpaRepository<UserEntity, Integer> {
 
 
     boolean existsByEmail(String email);
+    boolean existsByLoginId(String loginId);
+
 
     Optional<UserEntity> findByEmail(String email);
 
     Optional<UserEntity> findByLoginId(String loginId);
+
+    Optional<UserEntity> findBySocialTypeAndLoginId(SocialType socialType, String id);
 
 }

--- a/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
+++ b/src/main/java/com/example/basketballmatching/user/repository/UserRepository.java
@@ -1,16 +1,18 @@
 package com.example.basketballmatching.user.repository;
 
 
-import com.example.basketballmatching.user.entity.User;
+import com.example.basketballmatching.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Integer> {
+public interface UserRepository extends JpaRepository<UserEntity, Integer> {
 
 
     boolean existsByEmail(String email);
 
-    Optional<User> findByEmail(String email);
+    Optional<UserEntity> findByEmail(String email);
+
+    Optional<UserEntity> findByLoginId(String loginId);
 
 }

--- a/src/main/java/com/example/basketballmatching/user/service/UserService.java
+++ b/src/main/java/com/example/basketballmatching/user/service/UserService.java
@@ -1,7 +1,6 @@
-package com.example.basketballmatching.user;
+package com.example.basketballmatching.user.service;
 
 import com.example.basketballmatching.global.exception.CustomException;
-import com.example.basketballmatching.global.exception.ErrorCode;
 import com.example.basketballmatching.user.dto.UserDto;
 import com.example.basketballmatching.user.entity.UserEntity;
 import com.example.basketballmatching.user.repository.UserRepository;

--- a/src/main/java/com/example/basketballmatching/user/type/UserType.java
+++ b/src/main/java/com/example/basketballmatching/user/type/UserType.java
@@ -1,6 +1,15 @@
 package com.example.basketballmatching.user.type;
 
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum UserType {
 
-    USER, ADMIN
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN");
+
+    private final String description;
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Welcome</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            text-align: center;
+            margin-top: 50px;
+        }
+        h1 {
+            color: #333;
+        }
+        .login-link {
+            display: inline-block;
+            margin-top: 20px;
+            padding: 10px 20px;
+            background-color: #FEE500;
+            color: #000;
+            text-decoration: none;
+            border-radius: 5px;
+            font-weight: bold;
+        }
+        .login-link:hover {
+            background-color: #FFC107;
+        }
+    </style>
+</head>
+<body>
+<h1>Welcome to the Application!</h1>
+<a class="login-link" href="http://localhost:8080/api/oauth2/login/kakao">Kakao Login</a>
+</body>
+</html>

--- a/src/test/java/com/example/basketballmatching/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/basketballmatching/auth/service/AuthServiceTest.java
@@ -1,0 +1,18 @@
+package com.example.basketballmatching.auth.service;
+
+import com.example.basketballmatching.user.repository.UserRepository;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+class AuthServiceTest {
+
+    @Autowired
+    private  UserRepository userRepository;
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**


- 카카오 로그인 API 구현
   - 카카오 회원 로그인 시 카카오 서버로부터 인가 코드 발급 요청
   - 동의 화면 진행 후 302 Redirect URI 로 인가 코드 전달
   - 해당 코드로 토큰 발급
   - 로그인 시 헤더에 AccessToken 발급
   - 기 로그인 회원인 경우 토큰만 발급

- 로그인 시 토큰 발급 후 성공이 됬는데 두번 요청이 가서 KOE320 오류
   - KOE320 : 동일한 인가 코드를 두 번 이상 사용하거나, 이미 만료된 인가 코드를 사용한 경우, 혹은 인가 코드를 찾을 수 없는 경우
   - 추후 수정 예정



### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 