### PR TITLE
[feat]: 경기검색/정렬

### DIFF
--- a/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/controller/GameUserController.java
@@ -1,0 +1,54 @@
+package com.example.basketballmatching.gameUsers.controller;
+
+
+import com.example.basketballmatching.game.type.CityName;
+import com.example.basketballmatching.game.type.FieldStatus;
+import com.example.basketballmatching.game.type.Gender;
+import com.example.basketballmatching.game.type.MatchFormat;
+import com.example.basketballmatching.gameUsers.dto.GameSearchDto;
+import com.example.basketballmatching.gameUsers.service.GameUserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/game-user")
+public class GameUserController {
+
+    private final GameUserService gameUserService;
+
+    @GetMapping("/search")
+    public ResponseEntity<List<GameSearchDto>> findFilteredGame(
+            @RequestParam(required = false) LocalDate localDate,
+            @RequestParam(required = false) CityName cityName,
+            @RequestParam(required = false) FieldStatus fieldStatus,
+            @RequestParam(required = false) Gender gender,
+            @RequestParam(required = false) MatchFormat matchFormat
+            ) {
+
+        return ResponseEntity.ok(
+                gameUserService.findFilteredGame(
+                        localDate, cityName, fieldStatus, gender, matchFormat)
+        );
+    }
+
+
+
+    @GetMapping("/search-address")
+    public ResponseEntity<List<GameSearchDto>> searchAddress(
+            @RequestParam String address
+    ) {
+        return ResponseEntity.ok(
+                gameUserService.searchAddress(address)
+        );
+    }
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/dto/GameSearchDto.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/dto/GameSearchDto.java
@@ -1,0 +1,64 @@
+package com.example.basketballmatching.gameUsers.dto;
+
+import com.example.basketballmatching.game.entity.GameEntity;
+import com.example.basketballmatching.game.type.CityName;
+import com.example.basketballmatching.game.type.FieldStatus;
+import com.example.basketballmatching.game.type.Gender;
+import com.example.basketballmatching.game.type.MatchFormat;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class GameSearchDto {
+
+    private Integer gameId;
+
+    private String title;
+
+    private String content;
+
+    private Integer headCount;
+
+    private FieldStatus fieldStatus;
+
+    private Gender gender;
+
+    private LocalDateTime startDateTime;
+
+    private LocalDateTime createdDateTime;
+
+    private LocalDateTime deletedDateTime;
+
+    private String address;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    private CityName cityName;
+
+    private MatchFormat matchFormat;
+
+    public static GameSearchDto of(GameEntity gameEntity) {
+        return GameSearchDto.builder()
+                .gameId(gameEntity.getGameId())
+                .title(gameEntity.getTitle())
+                .content(gameEntity.getContent())
+                .headCount(gameEntity.getHeadCount())
+                .fieldStatus(gameEntity.getFieldStatus())
+                .gender(gameEntity.getGender())
+                .startDateTime(gameEntity.getStartDateTime())
+                .address(gameEntity.getAddress())
+                .latitude(gameEntity.getLatitude())
+                .longitude(gameEntity.getLongitude())
+                .cityName(gameEntity.getCityName())
+                .matchFormat(gameEntity.getMatchFormat())
+                .build();
+
+
+    }
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/repository/GameSpecification.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/repository/GameSpecification.java
@@ -1,0 +1,61 @@
+package com.example.basketballmatching.gameUsers.repository;
+
+import com.example.basketballmatching.game.entity.GameEntity;
+import com.example.basketballmatching.game.type.CityName;
+import com.example.basketballmatching.game.type.FieldStatus;
+import com.example.basketballmatching.game.type.Gender;
+import com.example.basketballmatching.game.type.MatchFormat;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDate;
+
+public class GameSpecification {
+
+    public static Specification<GameEntity> withCityName(CityName cityName) {
+        return ((root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("cityName"), cityName));
+    }
+
+    public static Specification<GameEntity> withFieldStatus(
+            FieldStatus fieldStatus
+    ) {
+        return ((root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("fieldStatus"), fieldStatus));
+    }
+
+    public static Specification<GameEntity> withGender(Gender gender) {
+        return ((root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("gender"), gender));
+    }
+
+    public static Specification<GameEntity> withMatchFormat(
+            MatchFormat matchFormat
+    ) {
+        return ((root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(root.get("matchFormat"), matchFormat));
+    }
+
+    public static Specification<GameEntity> startDate(
+            LocalDate date
+    ) {
+        return ((root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(
+                        root.get("startDateTime").as(LocalDate.class), date
+                ));
+    }
+
+    public static Specification<GameEntity> notDeleted() {
+        return ((root, query, criteriaBuilder) ->
+                criteriaBuilder.isNull(root.get("deletedDateTime")));
+    }
+
+    public static Specification<GameEntity> withDate(
+            LocalDate date
+    ) {
+        return ((root, query, criteriaBuilder) ->
+                criteriaBuilder.equal(
+                        root.get("startDateTime").as(LocalDate.class), date
+                ));
+    }
+}
+

--- a/src/main/java/com/example/basketballmatching/gameUsers/repository/GameUserRepository.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/repository/GameUserRepository.java
@@ -1,0 +1,22 @@
+package com.example.basketballmatching.gameUsers.repository;
+
+
+import com.example.basketballmatching.game.entity.GameEntity;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface GameUserRepository extends JpaRepository<GameEntity, Integer> {
+
+
+    List<GameEntity> findAll(Specification<GameEntity> specification);
+
+    List<GameEntity> findByAddressContainsIgnoreCaseAndStartDateTimeAfterOrderByStartDateTimeAsc(
+            String partOfAddress, LocalDateTime currentDateTime
+    );
+
+}

--- a/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
+++ b/src/main/java/com/example/basketballmatching/gameUsers/service/GameUserService.java
@@ -1,0 +1,108 @@
+package com.example.basketballmatching.gameUsers.service;
+
+
+import com.example.basketballmatching.game.entity.GameEntity;
+import com.example.basketballmatching.game.type.CityName;
+import com.example.basketballmatching.game.type.FieldStatus;
+import com.example.basketballmatching.game.type.Gender;
+import com.example.basketballmatching.game.type.MatchFormat;
+import com.example.basketballmatching.gameUsers.dto.GameSearchDto;
+import com.example.basketballmatching.gameUsers.repository.GameSpecification;
+import com.example.basketballmatching.gameUsers.repository.GameUserRepository;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class GameUserService {
+
+    private final GameUserRepository gameUserRepository;
+
+    public List<GameSearchDto> findFilteredGame(
+            LocalDate localDate,
+            CityName cityName,
+            FieldStatus fieldStatus,
+            Gender gender,
+            MatchFormat matchFormat) {
+
+        Specification<GameEntity> gameEntitySpec = getGameEntitySpec(localDate, cityName, fieldStatus, gender, matchFormat);
+
+
+        List<GameEntity> gameListNow = gameUserRepository.findAll(gameEntitySpec);
+
+
+
+        return getGameSearch(gameListNow);
+
+    }
+
+    public List<GameSearchDto> searchAddress(String address) {
+        List<GameEntity> gameEntities =
+                gameUserRepository.findByAddressContainsIgnoreCaseAndStartDateTimeAfterOrderByStartDateTimeAsc(
+                        address, LocalDateTime.now()
+                );
+
+        return getGameSearch(gameEntities);
+    }
+
+    private static Specification<GameEntity> getGameEntitySpec(
+            LocalDate localDate,
+            CityName cityName,
+            FieldStatus fieldStatus,
+            Gender gender,
+            MatchFormat matchFormat
+    ) {
+
+        log.info("경기 검색 시작");
+        Specification<GameEntity> specification = Specification.where(
+                GameSpecification.startDate(LocalDate.now())
+                        .and(GameSpecification.notDeleted())
+        );
+
+        if (localDate != null) {
+            specification = specification.and(GameSpecification.withDate(localDate)).and(GameSpecification.notDeleted());
+        };
+
+        if (cityName != null) {
+            specification = specification.and(GameSpecification.withCityName(cityName
+            ));
+        }
+
+        if (fieldStatus != null) {
+            specification = specification.and(GameSpecification.withFieldStatus(fieldStatus));
+        }
+
+        if (gender != null) {
+            specification = specification.and(GameSpecification.withGender(gender));
+        }
+
+        if (matchFormat != null) {
+            specification.and(GameSpecification.withMatchFormat(matchFormat));
+        }
+
+        return specification;
+    }
+
+    private static List<GameSearchDto> getGameSearch(
+            List<GameEntity> gameListNow) {
+
+        log.info("경기 리스트 조회 시작");
+
+        List<GameSearchDto> gameList = new ArrayList<>();
+
+        gameListNow.forEach((e) ->
+                gameList.add(GameSearchDto.of(e)));
+
+        return  gameList;
+    }
+
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**

**TO-BE**
- 정렬
   - 검색하는 시점의 날짜 기준으로 정렬
   - 지난 날짜의 경기 검색 결과는 가져오지 않음

- 도시로 검색
   - 검색하는 도시에 해당 되는 경기를 오름 차순으로 정렬
   - 검색하는 날짜를 기준으로 지난 시간의 경기들은 가져오지 않음
- 주소로 검색
   - 쿼리 와일드 카드를 통해 주소 일부분만의 검색으로 경기 정렬
   - 검색하는 날짜를 기준으로 지난 시간의 경기들은 가져오지 않음



### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 